### PR TITLE
interactive CPU0 governor

### DIFF
--- a/init.mako.rc
+++ b/init.mako.rc
@@ -257,7 +257,7 @@ on post-fs-data
     write /sys/module/pm_8x60/modes/cpu2/standalone_power_collapse/idle_enabled 1
     write /sys/module/pm_8x60/modes/cpu3/standalone_power_collapse/idle_enabled 1
     write /sys/module/pm_8x60/modes/cpu0/power_collapse/idle_enabled 1
-    write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor "ondemand"
+    write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor "interactive"
     write /sys/devices/system/cpu/cpu1/cpufreq/scaling_governor "ondemand"
     write /sys/devices/system/cpu/cpu2/cpufreq/scaling_governor "ondemand"
     write /sys/devices/system/cpu/cpu3/cpufreq/scaling_governor "ondemand"


### PR DESCRIPTION
changing cpu governor for mako. Interactive instead ondemand. Branch hybris-11.0
